### PR TITLE
Changed: Treat "/" as null search filter. Fixed: Bug fix in Iteration…

### DIFF
--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -22,7 +22,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string Version = "2.16.0110.0";
+        internal const string Version = "2.16.0115.0";
 
         /// <summary>
         /// File Version information for the assembly consists of the following four values:
@@ -31,6 +31,6 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string FileVersion = "2.16.0110.0";
+        internal const string FileVersion = "2.16.0115.0";
     }
 }

--- a/src/WorkflowActivityLibrary/Activities/CreateResource.cs
+++ b/src/WorkflowActivityLibrary/Activities/CreateResource.cs
@@ -771,18 +771,20 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Activitie
         /// <param name="e">The <see cref="ConditionalEventArgs"/> instance containing the event data.</param>
         private void ForEachIteration_UntilCondition(object sender, ConditionalEventArgs e)
         {
-            Logger.Instance.WriteMethodEntry(EventIdentifier.CreateResourceForEachIterationUntilCondition, "Iteration: '{0}' of '{1}'. ", this.iterations, this.ForEachIteration.InitialChildData.Count);
+            Logger.Instance.WriteMethodEntry(EventIdentifier.CreateResourceForEachIterationUntilCondition, "Iteration: '{0}' of '{1}'. ", this.iterations, this.ForEachIteration.InitialChildData == null ? 0 : this.ForEachIteration.InitialChildData.Count);
 
+            int maxIterations = 0;
             try
             {
-                if (this.iterations == this.ForEachIteration.InitialChildData.Count || this.breakIteration)
+                maxIterations = this.ForEachIteration.InitialChildData == null ? 0 : this.ForEachIteration.InitialChildData.Count;
+                if (this.iterations == maxIterations || this.breakIteration)
                 {
                     e.Result = true;
                 }
             }
             finally
             {
-                Logger.Instance.WriteMethodExit(EventIdentifier.CreateResourceForEachIterationUntilCondition, "Iteration: '{0}' of '{1}'. Condition evaluated '{2}'.", this.iterations, this.ForEachIteration.InitialChildData.Count, e.Result);
+                Logger.Instance.WriteMethodExit(EventIdentifier.CreateResourceForEachIterationUntilCondition, "Iteration: '{0}' of '{1}'. Condition evaluated '{2}'.", this.iterations, maxIterations, e.Result);
             }
         }
 

--- a/src/WorkflowActivityLibrary/Activities/UpdateResources.cs
+++ b/src/WorkflowActivityLibrary/Activities/UpdateResources.cs
@@ -587,18 +587,20 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Activitie
         /// <param name="e">The <see cref="ConditionalEventArgs"/> instance containing the event data.</param>
         private void ForEachIteration_UntilCondition(object sender, ConditionalEventArgs e)
         {
-            Logger.Instance.WriteMethodEntry(EventIdentifier.UpdateResourcesForEachIterationUntilCondition, "Iteration: '{0}' of '{1}'. ", this.iterations, this.ForEachIteration.InitialChildData.Count);
+            Logger.Instance.WriteMethodEntry(EventIdentifier.UpdateResourcesForEachIterationUntilCondition, "Iteration: '{0}' of '{1}'. ", this.iterations, this.ForEachIteration.InitialChildData == null ? 0 : this.ForEachIteration.InitialChildData.Count);
 
+            int maxIterations = 0;
             try
             {
-                if (this.iterations == this.ForEachIteration.InitialChildData.Count || this.breakIteration)
+                maxIterations = this.ForEachIteration.InitialChildData == null ? 0 : this.ForEachIteration.InitialChildData.Count;
+                if (this.iterations == maxIterations || this.breakIteration)
                 {
                     e.Result = true;
                 }
             }
             finally
             {
-                Logger.Instance.WriteMethodExit(EventIdentifier.UpdateResourcesForEachIterationUntilCondition, "Iteration: '{0}' of '{1}'. Condition evaluated '{2}'.", this.iterations, this.ForEachIteration.InitialChildData.Count, e.Result);
+                Logger.Instance.WriteMethodExit(EventIdentifier.UpdateResourcesForEachIterationUntilCondition, "Iteration: '{0}' of '{1}'. Condition evaluated '{2}'.", this.iterations, maxIterations, e.Result);
             }
         }
 

--- a/src/WorkflowActivityLibrary/Common/EventIdentifier.cs
+++ b/src/WorkflowActivityLibrary/Common/EventIdentifier.cs
@@ -549,6 +549,11 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Common
         public const int FindResourcesReadFoundResourceExecuteCode = 11204;
 
         /// <summary>
+        /// The event identifier for FindResources ResolvedFilterIsNotNull_Condition events
+        /// </summary>
+        public const int FindResourcesResolvedFilterIsNotNullCondition = 11205;
+
+        /// <summary>
         /// The event identifier for ResolveLookups Constructor events
         /// </summary>
         public const int ResolveLookupsConstructor = 11301;

--- a/src/WorkflowActivityLibrary/ComponentActivities/FindResources.Designer.cs
+++ b/src/WorkflowActivityLibrary/ComponentActivities/FindResources.Designer.cs
@@ -28,11 +28,14 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Component
             this.CanModifyActivities = true;
             System.Workflow.ComponentModel.ActivityBind activitybind1 = new System.Workflow.ComponentModel.ActivityBind();
             System.Workflow.ComponentModel.ActivityBind activitybind2 = new System.Workflow.ComponentModel.ActivityBind();
+            System.Workflow.Activities.CodeCondition codecondition1 = new System.Workflow.Activities.CodeCondition();
             System.Workflow.ComponentModel.ActivityBind activitybind3 = new System.Workflow.ComponentModel.ActivityBind();
             System.Workflow.ComponentModel.ActivityBind activitybind4 = new System.Workflow.ComponentModel.ActivityBind();
             System.Workflow.ComponentModel.ActivityBind activitybind5 = new System.Workflow.ComponentModel.ActivityBind();
             this.ReadFoundResource = new System.Workflow.Activities.CodeActivity();
             this.Find = new Microsoft.ResourceManagement.Workflow.Activities.EnumerateResourcesActivity();
+            this.ResolvedFilterIsNotNull = new System.Workflow.Activities.IfElseBranchActivity();
+            this.IfResolvedFilterIsNotNull = new System.Workflow.Activities.IfElseActivity();
             this.ResolveFilter = new MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.ComponentActivities.ResolveLookupString();
             this.Prepare = new System.Workflow.Activities.CodeActivity();
             // 
@@ -56,21 +59,32 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Component
             this.Find.SetBinding(Microsoft.ResourceManagement.Workflow.Activities.EnumerateResourcesActivity.ActorIdProperty, ((System.Workflow.ComponentModel.ActivityBind)(activitybind1)));
             this.Find.SetBinding(Microsoft.ResourceManagement.Workflow.Activities.EnumerateResourcesActivity.XPathFilterProperty, ((System.Workflow.ComponentModel.ActivityBind)(activitybind2)));
             // 
+            // ResolvedFilterIsNotNull
+            // 
+            this.ResolvedFilterIsNotNull.Activities.Add(this.Find);
+            codecondition1.Condition += new System.EventHandler<System.Workflow.Activities.ConditionalEventArgs>(this.ResolvedFilterIsNotNull_Condition);
+            this.ResolvedFilterIsNotNull.Condition = codecondition1;
+            this.ResolvedFilterIsNotNull.Name = "ResolvedFilterIsNotNull";
+            // 
+            // IfResolvedFilterIsNotNull
+            // 
+            this.IfResolvedFilterIsNotNull.Activities.Add(this.ResolvedFilterIsNotNull);
+            this.IfResolvedFilterIsNotNull.Name = "IfResolvedFilterIsNotNull";
+            // 
             // ResolveFilter
             // 
             this.ResolveFilter.ComparedRequestId = new System.Guid("00000000-0000-0000-0000-000000000000");
             this.ResolveFilter.Name = "ResolveFilter";
-            this.ResolveFilter.QueryResults = null;
-            this.ResolveFilter.Resolved = null;
             activitybind3.Name = "FindResources";
-            activitybind3.Path = "XPathFilter";
+            activitybind3.Path = "QueryResults";
+            this.ResolveFilter.Resolved = null;
             activitybind4.Name = "FindResources";
-            activitybind4.Path = "Value";
+            activitybind4.Path = "XPathFilter";
             activitybind5.Name = "FindResources";
-            activitybind5.Path = "QueryResults";
-            this.ResolveFilter.SetBinding(MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.ComponentActivities.ResolveLookupString.StringForResolutionProperty, ((System.Workflow.ComponentModel.ActivityBind)(activitybind3)));
-            this.ResolveFilter.SetBinding(MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.ComponentActivities.ResolveLookupString.ValueProperty, ((System.Workflow.ComponentModel.ActivityBind)(activitybind4)));
-            this.ResolveFilter.SetBinding(MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.ComponentActivities.ResolveLookupString.QueryResultsProperty, ((System.Workflow.ComponentModel.ActivityBind)(activitybind5)));
+            activitybind5.Path = "Value";
+            this.ResolveFilter.SetBinding(MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.ComponentActivities.ResolveLookupString.StringForResolutionProperty, ((System.Workflow.ComponentModel.ActivityBind)(activitybind4)));
+            this.ResolveFilter.SetBinding(MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.ComponentActivities.ResolveLookupString.ValueProperty, ((System.Workflow.ComponentModel.ActivityBind)(activitybind5)));
+            this.ResolveFilter.SetBinding(MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.ComponentActivities.ResolveLookupString.QueryResultsProperty, ((System.Workflow.ComponentModel.ActivityBind)(activitybind3)));
             // 
             // Prepare
             // 
@@ -81,38 +95,36 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Component
             // 
             this.Activities.Add(this.Prepare);
             this.Activities.Add(this.ResolveFilter);
-            this.Activities.Add(this.Find);
+            this.Activities.Add(this.IfResolvedFilterIsNotNull);
             this.Name = "FindResources";
             this.CanModifyActivities = false;
 
         }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
         #endregion
 
+        private IfElseBranchActivity ResolvedFilterIsNotNull;
+        private IfElseActivity IfResolvedFilterIsNotNull;
         private ResolveLookupString ResolveFilter;
-
         private Microsoft.ResourceManagement.Workflow.Activities.EnumerateResourcesActivity Find;
-
         private CodeActivity Prepare;
-
         private CodeActivity ReadFoundResource;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     }
 }

--- a/src/WorkflowActivityLibrary/ComponentActivities/FindResources.cs
+++ b/src/WorkflowActivityLibrary/ComponentActivities/FindResources.cs
@@ -23,7 +23,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Component
     using MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Common;
 
     #endregion
-    
+
     /// <summary>
     /// Finds resources
     /// </summary>
@@ -117,7 +117,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Component
                 this.SetValue(XPathFilterProperty, value);
             }
         }
-        
+
         /// <summary>
         /// Gets or sets the value which should be used for [//Value/...] lookup resolution.
         /// </summary>
@@ -364,7 +364,29 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Component
                 Logger.Instance.WriteMethodExit(EventIdentifier.FindResourcesReadFoundResourceExecuteCode, "XPathFilter: '{0}'.", this.XPathFilter);
             }
         }
-    
+
+        /// <summary>
+        /// Handles the Condition event of the ResolvedFilterIsNotNull condition.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="ConditionalEventArgs"/> instance containing the event data.</param>
+        private void ResolvedFilterIsNotNull_Condition(object sender, ConditionalEventArgs e)
+        {
+            Logger.Instance.WriteMethodEntry(EventIdentifier.FindResourcesResolvedFilterIsNotNullCondition);
+
+            string resolvedFilter = null;
+            try
+            {
+                resolvedFilter = this.ResolveFilter.Resolved;
+
+                // Since we are supporting resolution, treat "/" as a null search filter.
+                e.Result = !string.IsNullOrEmpty(resolvedFilter) && resolvedFilter != "/";
+            }
+            finally
+            {
+                Logger.Instance.WriteMethodExit(EventIdentifier.FindResourcesResolvedFilterIsNotNullCondition, "Resolved Filter : '{0}', Condition evaluated '{1}'.", resolvedFilter, e.Result);
+            }
+        }
         #endregion
     }
 }


### PR DESCRIPTION
Changed: Since search filter can be expressed as an expression, "/" can be treated as a null search filter. This is equivalent to query returning zero objects.
Fixed - Added null check in the ForEachIteration_UntilCondition function of UpdateResources and CreateResource activities to prevent crash when AEC is defined, but Iteration not.