### PR TITLE
The [//Request/RequestParameter] lookup resolution change for a SystemEvent request

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,14 @@ All notable changes to MIMWAL project will be documented in this file. The "Unre
 
 ------------
 
+### Version 2.16.0320.0
+
+#### Changed
+
+* The `[//Request/RequestParameter]` lookup for a SystemEvent request will resolve to request parameters in the parent request.
+
+------------
+
 ### Version 2.16.0315.0
 
 #### Added

--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -22,7 +22,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string Version = "2.16.0315.0";
+        internal const string Version = "2.16.0320.0";
 
         /// <summary>
         /// File Version information for the assembly consists of the following four values:
@@ -31,6 +31,6 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string FileVersion = "2.16.0315.0";
+        internal const string FileVersion = "2.16.0320.0";
     }
 }

--- a/src/WorkflowActivityLibrary/Common/ExpressionFunction.cs
+++ b/src/WorkflowActivityLibrary/Common/ExpressionFunction.cs
@@ -344,7 +344,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Common
         /// <typeparam name="T">Type of the object to be deserialized</typeparam>
         /// <param name="xml">Serialized representation of the specified type</param>
         /// <returns>The Object being deserialized.</returns>
-        private static T DeserializeObject<T>(string xml)
+        internal static T DeserializeObject<T>(string xml)
         where T : class
         {
             T t;


### PR DESCRIPTION
The `[//Request/RequestParameter]` lookup for a SystemEvent request will resolve to request parameters in the parent request so that the request parameters of the requests generated by the batch updates from the Sync Engine can be correctly parsed.