### PR TITLE
Updates to FormatMultivaluedList and ConvertToString functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+/src/ReferencedAssemblies
+/src/Scripts
+/src/SolutionOutput

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,14 @@ All notable changes to MIMWAL project will be documented in this file. The "Unre
 ### Version [Unreleased]
 
 * Support for multi-valued attributes in `[//Effective]` lookup in AuthZ workflows.
+* Implement Approve Request Activity.
+
+### Version 2.16.1028.0
+
+#### Changed
+
+* [FormatMultivaluedList][FormatMultivaluedListFunction] function now supports list of variable lengths as input to format. It also no more expects the list to be of strings. The input can be any object type.
+* [ConvertToString][ConvertToStringFunction] function now supports a Guid as input.
 
 ------------
 
@@ -12,13 +20,13 @@ All notable changes to MIMWAL project will be documented in this file. The "Unre
 
 #### Changed
 
-*  RunPowerShellScript User for can now be specified in the UPN format. The Domain\UserName or UPN format is also only required if "Impersonate PowerShell User" option is selected.
-*  Iteration in CreateResource, DeleteResource and UpdateResources activities now re-evaluates not only `[//Value]` expressions but also `[//WorkflowData]` expressions.
+* RunPowerShellScript User for can now be specified in the UPN format. The Domain\UserName or UPN format is also only required if "Impersonate PowerShell User" option is selected.
+* Iteration in CreateResource, DeleteResource and UpdateResources activities now re-evaluates not only `[//Value]` expressions but also `[//WorkflowData]` expressions.
 
 #### Added
 
-* `FormatMultivaluedString` function now supports more than one list of strings as input to format.
-* `ConvertToUniqueIdentifier` now supports a Guid in byte[] format as input.
+* [FormatMultivaluedList][FormatMultivaluedListFunction] function now supports more than one list of strings as input to format.
+* [ConvertToUniqueIdentifier][ConvertToUniqueIdentifierFunction] now supports a Guid in byte[] format as input.
 
 ------------
 
@@ -64,7 +72,7 @@ All notable changes to MIMWAL project will be documented in this file. The "Unre
 #### Added
 
 * Support for executing a collection of Queries.
-* New function `FormatMultivaluedList`.
+* New function [FormatMultivaluedList][FormatMultivaluedList].
 * Support for `[//Value]` lookup in Request Actor expressions in CreateResource, DeleteResources and UpdateResources activities.
 
 #### Fixed
@@ -117,3 +125,6 @@ All notable changes to MIMWAL project will be documented in this file. The "Unre
 [RunPowerShellScriptActivity]: https://github.com/Microsoft/MIMWAL/wiki/Run-PowerShell-Script-Activity
 [UpdateResourcesActivity]: https://github.com/Microsoft/MIMWAL/wiki/Update-Resources-Activity
 [EvaluateExpressionFunction]: https://github.com/Microsoft/MIMWAL/wiki/EvaluateExpression-Function
+[FormatMultivaluedListFunction]: https://github.com/Microsoft/MIMWAL/wiki/FormatMultivaluedList-Function
+[ConvertToUniqueIdentifierFunction]: https://github.com/Microsoft/MIMWAL/wiki/ConvertToUniqueIdentifier-Function
+[ConvertToStringFunction]: https://github.com/Microsoft/MIMWAL/wiki/ConvertToString-Function

--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -22,7 +22,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string Version = "2.16.0710.0";
+        internal const string Version = "2.16.1028.0";
 
         /// <summary>
         /// File Version information for the assembly consists of the following four values:
@@ -31,6 +31,6 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string FileVersion = "2.16.0710.0";
+        internal const string FileVersion = "2.16.1028.0";
     }
 }

--- a/src/WorkflowActivityLibrary/Messages.Designer.cs
+++ b/src/WorkflowActivityLibrary/Messages.Designer.cs
@@ -313,6 +313,15 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The function &apos;{0}&apos; expects first parameter to be of type &apos;{1}&apos; or &apos;{2}&apos; or &apos;{3}&apos;. It was supplied a &apos;{4}&apos; parameter..
+        /// </summary>
+        internal static string ExpressionFunction_InvalidFirstFunctionParameterTypeError3 {
+            get {
+                return ResourceManager.GetString("ExpressionFunction_InvalidFirstFunctionParameterTypeError3", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The function &apos;{0}&apos; expects &apos;{1}&apos; parameters. It was supplied &apos;{2}&apos; parameters..
         /// </summary>
         internal static string ExpressionFunction_InvalidFunctionParameterCountError {
@@ -462,6 +471,15 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary {
         internal static string ExpressionFunction_NullFunctionParameterError {
             get {
                 return ResourceManager.GetString("ExpressionFunction_NullFunctionParameterError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The function &apos;{0}&apos; requires the at least one parameter at position &apos;{1}&apos; or later to be not null..
+        /// </summary>
+        internal static string ExpressionFunction_NullFunctionParameterError2 {
+            get {
+                return ResourceManager.GetString("ExpressionFunction_NullFunctionParameterError2", resourceCulture);
             }
         }
         

--- a/src/WorkflowActivityLibrary/Messages.resx
+++ b/src/WorkflowActivityLibrary/Messages.resx
@@ -372,4 +372,10 @@
   <data name="ExpressionFunction_InvalidFunctionParameterError2" xml:space="preserve">
     <value>The function '{0}' expects list at position {1} to be of length '{2}'. It has a length of '{3}'.</value>
   </data>
+  <data name="ExpressionFunction_InvalidFirstFunctionParameterTypeError3" xml:space="preserve">
+    <value>The function '{0}' expects first parameter to be of type '{1}' or '{2}' or '{3}'. It was supplied a '{4}' parameter.</value>
+  </data>
+  <data name="ExpressionFunction_NullFunctionParameterError2" xml:space="preserve">
+    <value>The function '{0}' requires the at least one parameter at position '{1}' or later to be not null.</value>
+  </data>
 </root>


### PR DESCRIPTION
FormatMultivaluedList function now supports list of variable lengths as input to format. It also no more expects the list to be of strings. The input can be any object type.
ConvertToString function now supports a Guid as input.