### PR TITLE
PowerShell Activity - Error When Hashtable Has Null Values

### DIFF
--- a/src/WorkflowActivityLibrary/Activities/RunPowerShellScript.cs
+++ b/src/WorkflowActivityLibrary/Activities/RunPowerShellScript.cs
@@ -767,7 +767,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Activitie
                                 object value = results[s];
 
                                 // Values may come as PSObject types. In that case, read the base object.
-                                if (value.GetType() == typeof(PSObject))
+                                if (value != null && value.GetType() == typeof(PSObject))
                                 {
                                     value = ((PSObject)results[s]).BaseObject;
                                 }


### PR DESCRIPTION
Use Case:  Query SQL Server for data mappings to determine AD Access, O365 Access, etc. via MIMWAL PowerShell Activity

Basic Flow:  
1. MIMWAL PS Activity to query table in SQL Server and return hash table to WorkflowData
2. MIMWAL Update Resource Activity to transfer WorkflowData to Target attributes

Result:  
Unhandled Exception - object reference not set to an instance of an object.  Search Requests shows PostProcessingError - The Workflow Instance '<GUID>' encountered an internal error.  Verbose logging shows no particular information other than executing the Run_ExecuteCode function.

Investigation:
This pull request checks for null values prior to the PSObject type check as the hash table may contain null values for some fields and non-null values for others.

Other Notes:
More verbose logging surrounding the reading of the hash table may be beneficial to identify iteration of the hash table.  For example, "Started Reading Key ABC" and "Ended Reading Key XYZ".