### PR TITLE
Generate Unique Value activity - Disable default optimisation logic for Conflict Filter that uses starts-with() XPath function.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,8 +7,17 @@ All notable changes to MIMWAL project will be documented in this file. The "Unre
 * Support for multi-valued attributes in `[//Effective]` lookup in AuthZ workflows.
 * Implement Approve Request Activity.
 * Support for `[//Value]` lookups in Query definitions across rest of the activities.
+------------
+
+### Version 2.19.0111.0
+
+#### Changed
+
+* [Generate Unique Value Activity][GenerateUniqueValueActivity] now has the Conflict Filter search optimisation logic for the *starts-with* XPath function as documented in the [Wiki](https://github.com/Microsoft/MIMWAL/wiki/Generate-Unique-Value-Activity#conflict-filter) turned off by default.
+To get the backward compatible behaviour, define the app setting GenerateUniqueValueActivity_OptimizeUniquenessKey = true in the FIMService app.config.
 
 ------------
+
 ### Version 2.18.1110.0
 
 #### Changed
@@ -278,3 +287,4 @@ All notable changes to MIMWAL project will be documented in this file. The "Unre
 [WordFunction]: https://github.com/Microsoft/MIMWAL/wiki/Word-Function
 [WrapXPathFilterFunction]: https://github.com/Microsoft/MIMWAL/wiki/WrapXPathFilter-Function
 [MIMWalFunctionsTable]: https://github.com/Microsoft/MIMWAL/wiki/Functions-Table
+[GenerateUniqueValueActivity]: https://github.com/Microsoft/MIMWAL/wiki/Generate-Unique-Value-Activity

--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -22,7 +22,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string Version = "2.19.0110.0";
+        internal const string Version = "2.19.0111.0";
 
         /// <summary>
         /// File Version information for the assembly consists of the following four values:
@@ -31,6 +31,6 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string FileVersion = "2.19.0110.0";
+        internal const string FileVersion = "2.19.0111.0";
     }
 }

--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -22,7 +22,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string Version = "2.18.1110.0";
+        internal const string Version = "2.19.0110.0";
 
         /// <summary>
         /// File Version information for the assembly consists of the following four values:
@@ -31,6 +31,6 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string FileVersion = "2.18.1110.0";
+        internal const string FileVersion = "2.19.0110.0";
     }
 }

--- a/src/WorkflowActivityLibrary/Activities/GenerateUniqueValue.cs
+++ b/src/WorkflowActivityLibrary/Activities/GenerateUniqueValue.cs
@@ -538,15 +538,24 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Activitie
                 while (startIndex != -1)
                 {
                     int endIndex = filter.IndexOf(endToken, startIndex, StringComparison.OrdinalIgnoreCase);
-                    string s = filter.Substring(startIndex + startTokenLength + 1, endIndex - (startIndex + startTokenLength + 1)).Trim(new char[] { ' ', '(', ',' });
-                    attributes.Add(s);
+                    if (endIndex != -1)
+                    {
+                        string s = filter.Substring(startIndex + startTokenLength + 1, endIndex - (startIndex + startTokenLength + 1)).Trim(new char[] { ' ', '(', ',' });
+                        attributes.Add(s);
+                    }
+                    else
+                    {
+                        // just increment - should never be here as now this function should not get called unless this.optimizeUniquenessKey is set true via app.cong. Issue #61
+                        endIndex = startIndex + startTokenLength;
+                    }
+
                     filter = filter.Substring(endIndex);
                     startIndex = filter.IndexOf(startToken, StringComparison.Ordinal);
                 }
 
                 if (attributes.Count > 0)
                 {
-                    this.optimizeUniquenessKey = true;
+                    ////this.optimizeUniquenessKey = true; // Now this flag can only be set by app.config.
                     this.FindConflict.Attributes = attributes.ToArray();
                     Logger.Instance.WriteVerbose(EventIdentifier.GenerateUniqueValueSetAttributesToReadForConflictResources, "Filter: '{0}'. Attributes: '{1}'.", this.ConflictFilter, string.Join(";", attributes.ToArray()));
                 }

--- a/src/WorkflowActivityLibrary/Activities/GenerateUniqueValue.cs
+++ b/src/WorkflowActivityLibrary/Activities/GenerateUniqueValue.cs
@@ -524,7 +524,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Activitie
             Logger.Instance.WriteMethodEntry(EventIdentifier.GenerateUniqueValueSetAttributesToReadForConflictResources, "Filter: '{0}'.", this.ConflictFilter);
 
             this.FindConflict.Attributes = null;
-            this.optimizeUniquenessKey = false;
+            ////this.optimizeUniquenessKey = false; // Now this flag can only be set by app.config.
             string filter = this.ConflictFilter;
             try
             {

--- a/src/WorkflowActivityLibrary/Activities/GenerateUniqueValue.cs
+++ b/src/WorkflowActivityLibrary/Activities/GenerateUniqueValue.cs
@@ -207,6 +207,11 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Activitie
                 {
                     this.maxLoopCount = 512;
                 }
+
+                if (!bool.TryParse(ConfigurationManager.AppSettings["GenerateUniqueValueActivity_OptimizeUniquenessKey"], out this.optimizeUniquenessKey))
+                {
+                    this.optimizeUniquenessKey = false;
+                }
             }
             finally
             {
@@ -740,8 +745,11 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Activitie
             {
                 // Find the attributes to read on potentially conflicing resources
                 // so that the uniqueness seed can be repositioned instead of simply incremented
-                // when the conflict filter XPath uses a starts-with fuction 
-                this.SetAttributesToReadForConflictResources();
+                // when the conflict filter XPath uses a starts-with fuction
+                if (this.optimizeUniquenessKey)
+                {
+                    this.SetAttributesToReadForConflictResources();
+                }
 
                 // Default the uniqueness key to the specified uniqueness seed,
                 // resolve the first value expression in the list, and use that value to resolve


### PR DESCRIPTION
Use cases mentioned is the issue #67 and #61 can be supported by disabling the default optimisation logic for Conflict Filter that uses starts-with() XPath function. To continue to provide existing optimisation logic app setting GenerateUniqueValueActivity_OptimizeUniquenessKey = true can be defined in the FIMService app.config. There are no customer that are expected to need to define this override as the only known customer for which this (emergency) optimisation logic was coded has since implemented long term recommendation and redesigned the solution.