### PR TITLE
Fixed - GenerateUniqueValue Activity is now correctly backward compatible.

### DIFF
--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -22,7 +22,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string Version = "2.19.0111.0";
+        internal const string Version = "2.19.0112.0";
 
         /// <summary>
         /// File Version information for the assembly consists of the following four values:
@@ -31,6 +31,6 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string FileVersion = "2.19.0111.0";
+        internal const string FileVersion = "2.19.0112.0";
     }
 }

--- a/src/WorkflowActivityLibrary/Activities/GenerateUniqueValue.cs
+++ b/src/WorkflowActivityLibrary/Activities/GenerateUniqueValue.cs
@@ -559,6 +559,10 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Activitie
                     this.FindConflict.Attributes = attributes.ToArray();
                     Logger.Instance.WriteVerbose(EventIdentifier.GenerateUniqueValueSetAttributesToReadForConflictResources, "Filter: '{0}'. Attributes: '{1}'.", this.ConflictFilter, string.Join(";", attributes.ToArray()));
                 }
+                else
+                {
+                    this.optimizeUniquenessKey = false; // Turn the config flag off as the conflict filter does not use starts-with function.
+                }
             }
             finally
             {


### PR DESCRIPTION
When the app,config setting GenerateUniqueValueActivity_OptimizeUniquenessKey is set true to get the backward compatible behaviour, but the conflict filter itself does not have starts-with function, then turning off the internal this.optimizeUniquenessKey flag.