### PR TITLE
Adding CR() Function

### DIFF
--- a/src/WorkflowActivityLibrary/Common/EventIdentifier.cs
+++ b/src/WorkflowActivityLibrary/Common/EventIdentifier.cs
@@ -1294,6 +1294,11 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Common
         public const int ExpressionFunctionIndexByValue = 11687;
 
         /// <summary>
+        /// The event identifier for ExpressionFunction CR events
+        /// </summary>
+        public const int ExpressionFunctionCr = 11688;
+
+        /// <summary>
         /// The event identifier for LookupEvaluator Constructor events
         /// </summary>
         public const int LookupEvaluatorConstructor = 11701;
@@ -2752,6 +2757,11 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Common
         /// The event identifier for ExpressionFunction CRLF events
         /// </summary>
         public const int ExpressionFunctionCrlfInvalidFunctionParameterCountError = 41658;
+
+        /// <summary>
+        /// The event identifier for ExpressionFunction CR events
+        /// </summary>
+        public const int ExpressionFunctionCrInvalidFunctionParameterCountError = 41658;
 
         /// <summary>
         /// The event identifier for ExpressionFunction EscapeDNComponent events

--- a/src/WorkflowActivityLibrary/Common/ExpressionFunction.cs
+++ b/src/WorkflowActivityLibrary/Common/ExpressionFunction.cs
@@ -168,6 +168,9 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Common
                     case "CREATESQLPARAMETER2":
                         return this.CreateSqlParameter2();
 
+                    case "CR":
+                        return this.CR();
+
                     case "CRLF":
                         return this.CRLF();
 
@@ -4894,6 +4897,42 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Common
             finally
             {
                 Logger.Instance.WriteMethodExit(EventIdentifier.ExpressionFunctionConvertToString, "Evaluation Mode: '{0}'.", this.mode);
+            }
+        }
+
+        /// <summary>
+        /// This function is used to generate a Carriage Return.
+        /// Function Syntax: CR()
+        /// </summary>
+        /// <returns>A CR is the output.</returns>
+        private string CR()
+        {
+            Logger.Instance.WriteMethodEntry(EventIdentifier.ExpressionFunctionCr, "Evaluation Mode: '{0}'.", this.mode);
+
+            try
+            {
+                if (this.parameters.Count != 0)
+                {
+                    throw Logger.Instance.ReportError(EventIdentifier.ExpressionFunctionCrInvalidFunctionParameterCountError, new InvalidFunctionFormatException(Messages.ExpressionFunction_InvalidFunctionParameterCountError, this.function, 0, this.parameters.Count));
+                }
+
+                string result;
+
+                if (this.mode != EvaluationMode.Parse)
+                {
+                    result = "\n";
+                    Logger.Instance.WriteVerbose(EventIdentifier.ExpressionFunctionCr, "CR() returned '{0}'.", result);
+                }
+                else
+                {
+                    result = null;
+                }
+
+                return result;
+            }
+            finally
+            {
+                Logger.Instance.WriteMethodExit(EventIdentifier.ExpressionFunctionCr, "Evaluation Mode: '{0}'.", this.mode);
             }
         }
 


### PR DESCRIPTION
Adding new function which are equivalent to the existing CRLF() function, but it creates only a carriage return instead of carriage return line feed.
Usefull if you need to to regex or replace operations on a multiline textfield.