### PR TITLE
Regression Bug fix: WAL Lookup resolution support for PowerShellUserName and PowerShellUserPassword

### DIFF
--- a/src/Scripts/EncryptData.ps1
+++ b/src/Scripts/EncryptData.ps1
@@ -8,9 +8,10 @@
 	NOTE: Edit the Version and PublicKeyToken of the WAL AssemblyName to match the one that you have deployed in GAC.
 	Also edit the $encryptionCertThumbprint of cert to be used for certificate based encryption.
 	
-    Finding Assembly verion and PublicKeyToken
-        gacutil.exe -l | findstr WorkflowActivityLibrary
-    Creatinig a self signed certificate for MIMWAL (You can use a legacy CSP such as Microsoft Strong Cryptographic Provider as shown in the example below)
+    To find Assembly verion and PublicKeyToken
+        .\gacutil.exe -l | findstr WorkflowActivityLibrary
+    To create a self-signed certificate for MIMWAL, you must use a legacy CSP (as .NET 3.5 only supports legacy CSPs).
+    You can use a legacy CSP such as Microsoft Strong Cryptographic Provider as shown in the example below:
         $cert = New-SelfSignedCertificate -DnsName "MIMWAL Encryption (Do Not Delete)" -CertStoreLocation "cert:\LocalMachine\My" -Provider "Microsoft Strong Cryptographic Provider" -NotAfter (Get-Date).AddYears(20)
         $cert.Thumbprint
         As of version v2.18.1110.0, only FIMService account needs read access to the private key of the MIMWAL certificate created above.
@@ -18,9 +19,9 @@
 
 $Error.Clear()
 
-$walAssemblyVersion = "2.20.0523.0"
-$walAssemblyPublicKeyToken = "31bf3856ad364e35"
-$encryptionCertThumbprint = "9C697919FB2FB2D6324ADE42D5F8CB49E8778C08" # cert to be used for encryption (from the cert:\localmachine\my\ store).
+$walAssemblyVersion = "2.20.0723.0" # edit appropriately
+$walAssemblyPublicKeyToken = "31bf3856ad364e35" # edit appropriately
+$encryptionCertThumbprint = "9C697919FB2FB2D6324ADE42D5F8CB49E8778C08" # cert to be used for encryption (from the cert:\localmachine\my\ store). Edit appropriately
 
 Add-Type -AssemblyName "System.Security"
 # use the full name for WAL assembly to eliminate need to assembly redirects for dependent assemblies.

--- a/src/VersionInfo.cs
+++ b/src/VersionInfo.cs
@@ -22,7 +22,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string Version = "2.20.0523.0";
+        internal const string Version = "2.20.0723.0";
 
         /// <summary>
         /// File Version information for the assembly consists of the following four values:
@@ -31,6 +31,6 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary
         ///      Build Number (MMDD)
         ///      Revision (if any on the same day)
         /// </summary>
-        internal const string FileVersion = "2.20.0523.0";
+        internal const string FileVersion = "2.20.0723.0";
     }
 }

--- a/src/WorkflowActivityLibrary/Common/ExpressionFunction.cs
+++ b/src/WorkflowActivityLibrary/Common/ExpressionFunction.cs
@@ -2500,7 +2500,7 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Common
         }
 
         /// <summary>
-        /// This function is used to convert a date to the local time or specifed time zone.
+        /// This function is used to convert a date to the local time or specified time zone.
         /// Function Syntax: DateTimeUtcToLocalTime(date:DateTime [, TimeZoneId])
         /// </summary>
         /// <returns>The value of the specified UTC date expressed in the local time or specified time zone.</returns>
@@ -2848,7 +2848,6 @@ namespace MicrosoftServices.IdentityManagement.WorkflowActivityLibrary.Common
                                 index += 1;
                             }
                         }
-
                     }
 
                     Logger.Instance.WriteVerbose(EventIdentifier.ExpressionFunctionIndexByValue, "IndexByValue('{0}', '{1}') returned '{2}'.", this.parameters[0], this.parameters[1], result);


### PR DESCRIPTION
RunPowerShellScript activity fails to parse PowerShell user password as the ParseIfExpression check leads to an exception if the password is not a WAL expression.